### PR TITLE
Add Heroku postgres setup to routes/index.js

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,9 +1,28 @@
 var express = require('express');
 var router = express.Router();
 
+// Heroku postgres setup:
+const { Pool } = require('pg');
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: true
+});
+
 /* GET home page. */
 router.get('/', function(req, res, next) {
   res.render('index', { title: 'Express' });
 });
+router.get('/db', async (req, res) => {
+  try {
+    const client = await pool.connect()
+    const result = await client.query('SELECT * FROM test_table');
+    const results = { 'results': (result) ? result.rows : null };
+    res.render('pages/db', results);
+    client.release();
+  } catch (err) {
+    console.error(err);
+    res.send("Error " + err);
+  }
+})
 
 module.exports = router;


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Add Heroku postgres setup to routes/index.js 
 
Hopefully makes #2 happy
 
**The following checks have been completed:**
 - [N/A] Tested new feature(s) as well as any feasible edge cases
 - [x] Ran the test suite - all tests are passing
 - [N/A] Checked affected endpoints in Postman
 
**Notes:**
 - Need to do the following setup in the production environment: 
```
$heroku pg:psql
psql (9.5.2, server 9.6.2)
SSL connection (cipher: DHE-RSA-AES256-SHA, bits: 256)
Type "help" for help.
=> create table test_table (id integer, name text);
CREATE TABLE
=> insert into test_table values (1, 'hello database');
INSERT 0 1
=> \q
```
based on `https://devcenter.heroku.com/articles/getting-started-with-nodejs#provision-a-database` -- check `/db` route to make sure it works