### PR TITLE
Add fav locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Response:
 ```
 status: 200
 body:
-
 {
   "api_key": "6kzqk71x8vezd6odo5rp"
 }
@@ -139,5 +138,26 @@ body:
       },
     ]
   }
+}
+```
+
+### Adding a Favorite City (Denver, for example)
+Request:
+```
+POST /api/v1/favorites
+Content-Type: application/json
+Accept: application/json
+
+{
+  "location": <CITY AND STATE, FOR EXAMPLE "Denver, CO">,
+  api_key": "6kzqk71x8vezd6odo5rp"
+}
+```
+Response:
+```
+status: 200
+body:
+{
+  "message": "Denver, CO has been added to your favorites"
 }
 ```

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var usersRouter = require('./routes/users');
 var apiUsersRouter = require('./routes/api/v1/users');
 var apiSessionsRouter = require('./routes/api/v1/sessions');
 var apiForecastRouter = require('./routes/api/v1/forecast');
+var apiFavoritesRouter = require('./routes/api/v1/favorites');
 
 var app = express();
 
@@ -23,5 +24,6 @@ app.use('/users', usersRouter);
 app.use('/api/v1/users', apiUsersRouter);
 app.use('/api/v1/sessions', apiSessionsRouter);
 app.use('/api/v1/forecast', apiForecastRouter);
+app.use('/api/v1/favorites', apiFavoritesRouter);
 
 module.exports = app;

--- a/migrations/20190817213543-create-favorite-location.js
+++ b/migrations/20190817213543-create-favorite-location.js
@@ -8,11 +8,8 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.INTEGER
       },
-      location: {
+      name: {
         type: Sequelize.STRING
-      },
-      UserId: {
-        type: Sequelize.BIGINT
       },
       createdAt: {
         allowNull: false,

--- a/migrations/20190817213543-create-favorite-location.js
+++ b/migrations/20190817213543-create-favorite-location.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('FavoriteLocations', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      location: {
+        type: Sequelize.STRING
+      },
+      UserId: {
+        type: Sequelize.BIGINT
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('FavoriteLocations');
+  }
+};

--- a/migrations/20190817214727-addUserIdToFavoriteLocation.js
+++ b/migrations/20190817214727-addUserIdToFavoriteLocation.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      'FavoriteLocations',
+      'UserId',
+      {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      }
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'FavoriteLocations',
+      'UserId'
+    )
+  }
+};

--- a/models/favoritelocation.js
+++ b/models/favoritelocation.js
@@ -1,0 +1,11 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const FavoriteLocation = sequelize.define('FavoriteLocation', {
+    location: DataTypes.STRING,
+    UserId: DataTypes.BIGINT
+  }, {});
+  FavoriteLocation.associate = function(models) {
+    // associations can be defined here
+  };
+  return FavoriteLocation;
+};

--- a/models/favoritelocation.js
+++ b/models/favoritelocation.js
@@ -1,8 +1,7 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const FavoriteLocation = sequelize.define('FavoriteLocation', {
-    location: DataTypes.STRING,
-    UserId: DataTypes.BIGINT
+    name: DataTypes.STRING
   }, {});
   FavoriteLocation.associate = function(models) {
     // associations can be defined here

--- a/models/favoritelocation.js
+++ b/models/favoritelocation.js
@@ -4,7 +4,10 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING
   }, {});
   FavoriteLocation.associate = function(models) {
-    // associations can be defined here
+    FavoriteLocation.belongsTo(models.User, {
+      foreignKey: 'UserId',
+      as: 'user'
+    })
   };
   return FavoriteLocation;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -6,7 +6,9 @@ module.exports = (sequelize, DataTypes) => {
     apiKey: DataTypes.STRING
   }, {});
   User.associate = function(models) {
-    // associations can be defined here
+    User.hasMany(models.FavoriteLocation, {
+      as: 'favoriteLocations'
+    })
   };
   return User;
 };

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,0 +1,33 @@
+var express = require("express");
+var router = express.Router();
+var User = require('../../../models').User;
+
+function unauthorized(res) {
+  res.setHeader("Content-Type", "application/json");
+  res.status(401).send(JSON.stringify({ error: "Invalid API key" }));
+}
+
+/*POST new favorite location for the user*/
+router.post("/", function (req, res, next) {
+  let apiKey = req.body.api_key;
+
+  if (!apiKey) {
+    unauthorized(res);
+  } else {
+    User.findOne({
+      where: { apiKey: apiKey }
+    }).then(user => {
+      if (user) {
+        res.setHeader("Content-Type", "application/json");
+        // add new favorite for the user
+        res.status(200).send(JSON.stringify({
+          TODO: "something"
+        }));
+      } else {
+        unauthorized(res);
+      }
+    })
+  }
+});
+
+module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -10,6 +10,7 @@ function unauthorized(res) {
 /*POST new favorite location for the user*/
 router.post("/", function (req, res, next) {
   let apiKey = req.body.api_key;
+  let locationString = req.body.location;
 
   if (!apiKey) {
     unauthorized(res);
@@ -19,13 +20,20 @@ router.post("/", function (req, res, next) {
     }).then(user => {
       if (user) {
         res.setHeader("Content-Type", "application/json");
-        // add new favorite for the user
-        res.status(200).send(JSON.stringify({
-          TODO: "something"
-        }));
+        return user.createFavoriteLocation({
+          name: locationString
+        })
+        .then(response => {
+          res.status(200).send(JSON.stringify({
+            message: locationString + ' has been added to your favorites'
+          }));
+        })
       } else {
         unauthorized(res);
       }
+    })
+    .catch(err => {
+      res.status(500).send(JSON.stringify({ error: err }));
     })
   }
 });

--- a/routes/api/v1/sessions.js
+++ b/routes/api/v1/sessions.js
@@ -1,7 +1,6 @@
 var express = require("express");
 var router = express.Router();
 var User = require('../../../models').User;
-var security = require('../../../util/security');
 const bcrypt = require('bcrypt');
 
 /*POST new session (user login)*/

--- a/tests/helper/testCleanup.js
+++ b/tests/helper/testCleanup.js
@@ -1,5 +1,7 @@
 var User = require('../../models').User;
+var FavoriteLocation = require('../../models').FavoriteLocation;
 
 module.exports = async function cleanup() {
   await User.destroy({ where: {} })
+  await FavoriteLocation.destroy({ where: {} })
 }

--- a/tests/requests/favorites/create_favorites.spec.js
+++ b/tests/requests/favorites/create_favorites.spec.js
@@ -37,5 +37,7 @@ describe('api v1 favorites POST', () => {
           expect(response.body).toEqual(expected);
         });
     });
+    // TODO: test for bad API key
+    // TODO: test for missing API key
   });
 });

--- a/tests/requests/favorites/create_favorites.spec.js
+++ b/tests/requests/favorites/create_favorites.spec.js
@@ -38,12 +38,13 @@ describe('api v1 favorites POST', () => {
           }
           expect(response.body).toEqual(expected);
 
-          return FavoriteLocation.count()
+          return FavoriteLocation.findOne()
         })
-        .then(count => {
-          expect(count).toEqual(1)
+        .then(favoriteLocation => {
+          expect(favoriteLocation.name).toEqual(locationString);
         });
     });
+
     // TODO: test for bad API key
     // TODO: test for missing API key
   });

--- a/tests/requests/favorites/create_favorites.spec.js
+++ b/tests/requests/favorites/create_favorites.spec.js
@@ -22,7 +22,7 @@ describe('api v1 favorites POST', () => {
       })
         .then(user => {
           return request(app)
-            .get('/api/v1/favorites')
+            .post('/api/v1/favorites')
             .send({
               'location': locationString,
               'api_key': apiKey
@@ -34,7 +34,7 @@ describe('api v1 favorites POST', () => {
           let expected = {
             message: 'Denver, CO has been added to your favorites'
           }
-          expect(response.body).toEql(expected);
+          expect(response.body).toEqual(expected);
         });
     });
   });

--- a/tests/requests/favorites/create_favorites.spec.js
+++ b/tests/requests/favorites/create_favorites.spec.js
@@ -45,7 +45,65 @@ describe('api v1 favorites POST', () => {
         });
     });
 
-    // TODO: test for bad API key
-    // TODO: test for missing API key
+    test('bad API key', () => {
+      let email = 'email1112@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
+
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return request(app)
+            .post('/api/v1/favorites')
+            .send({
+              'location': locationString,
+              'api_key': "badAPIkey"
+            })
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(401);
+
+          expect(response.body).toEqual({ error: "Invalid API key" });
+
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(0);
+        });
+    });
+
+    test('missing API key', () => {
+      let email = 'email1113@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
+
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return request(app)
+            .post('/api/v1/favorites')
+            .send({
+              'location': locationString
+            })
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(401);
+
+          expect(response.body).toEqual({ error: "Invalid API key" });
+
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(0);
+        });
+    });
   });
 });

--- a/tests/requests/favorites/create_favorites.spec.js
+++ b/tests/requests/favorites/create_favorites.spec.js
@@ -1,0 +1,41 @@
+var request = require("supertest");
+var app = require('../../../app');
+var User = require('../../../models').User;
+var security = require('../../../util/security');
+var cleanup = require('../../helper/testCleanup');
+
+describe('api v1 favorites POST', () => {
+  beforeEach(() => {
+    cleanup()
+  });
+
+  describe('Test the add new favorites path', () => {
+    test('returns a message', () => {
+      let email = 'email1111@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return request(app)
+            .get('/api/v1/favorites')
+            .send({
+              'location': locationString,
+              'api_key': apiKey
+            })
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(200);
+
+          let expected = {
+            message: 'Denver, CO has been added to your favorites'
+          }
+          expect(response.body).toEql(expected);
+        });
+    });
+  });
+});

--- a/tests/requests/favorites/create_favorites.spec.js
+++ b/tests/requests/favorites/create_favorites.spec.js
@@ -1,6 +1,7 @@
 var request = require("supertest");
 var app = require('../../../app');
 var User = require('../../../models').User;
+var FavoriteLocation = require('../../../models').FavoriteLocation;
 var security = require('../../../util/security');
 var cleanup = require('../../helper/testCleanup');
 
@@ -15,6 +16,7 @@ describe('api v1 favorites POST', () => {
       let password = 'password'
       let locationString = 'Denver, CO'
       const apiKey = security.randomString()
+
       return User.create({
         email: email,
         passwordDigest: security.hashedPassword(password),
@@ -35,6 +37,11 @@ describe('api v1 favorites POST', () => {
             message: 'Denver, CO has been added to your favorites'
           }
           expect(response.body).toEqual(expected);
+
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(1)
         });
     });
     // TODO: test for bad API key

--- a/tests/requests/forecast/forecast.spec.js
+++ b/tests/requests/forecast/forecast.spec.js
@@ -104,6 +104,7 @@ describe('api v1 forecast', () => {
         })
     });
 
+    // TODO: add test for no API key sent
     test('no matching API key', () => {
       let email = "email111@example.com"
       let password = "password"
@@ -122,6 +123,7 @@ describe('api v1 forecast', () => {
         })
         .then(response => {
           expect(response.statusCode).toBe(401);
+          
           expect(Object.keys(response.body)).toContain('error')
           expect(response.body.error).toEqual("Invalid API key")
         })

--- a/tests/requests/forecast/forecast.spec.js
+++ b/tests/requests/forecast/forecast.spec.js
@@ -104,9 +104,8 @@ describe('api v1 forecast', () => {
         })
     });
 
-    // TODO: add test for no API key sent
     test('no matching API key', () => {
-      let email = "email111@example.com"
+      let email = "email12@example.com"
       let password = "password"
       const apiKey = security.randomString()
       return User.create({
@@ -124,8 +123,29 @@ describe('api v1 forecast', () => {
         .then(response => {
           expect(response.statusCode).toBe(401);
           
-          expect(Object.keys(response.body)).toContain('error')
-          expect(response.body.error).toEqual("Invalid API key")
+          expect(Object.keys(response.body)).toContain('error');
+          expect(response.body.error).toEqual("Invalid API key");
+        })
+    });
+
+    test('no API key sent', () => {
+      let email = "email13@example.com"
+      let password = "password"
+      const apiKey = security.randomString()
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return request(app)
+            .get('/api/v1/forecast?location=denver,co')
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(401);
+          
+          expect(Object.keys(response.body)).toContain('error');
+          expect(response.body.error).toEqual("Invalid API key");
         })
     });
   });


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Adds `POST /api/v1/favorites` endpoint (resolves #6). Requires `api_key` and `location` in the request body. Adds `favoritesRouter`.
 - Adds the `FavoriteLocations` table/model/associations with `User` (resolves #19). Adds 2 database migrations & updates the test cleanup method.
 - Adds test of missing API key for forecast endpoint
 - Removes some unnecessary require statements
 
**The following checks have been completed:**
 - [x] Tested new feature(s) as well as any feasible edge cases
 - [x] Ran the test suite - all tests are passing
 - [x] Checked affected endpoints in Postman
