### PR TITLE
Delete fav city

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Request:
 POST /api/v1/users
 Content-Type: application/json
 Accept: application/json
-
+body:
 {
   "email": "my_email@example.com",
   "password": "password"
@@ -29,6 +29,8 @@ Accept: application/json
 ```
 Response:
 ```
+status: 201
+body:
 {
   "api_key": "6kzqk71x8vezd6odo5rp",
 }
@@ -40,7 +42,7 @@ Request:
 POST /api/v1/sessions
 Content-Type: application/json
 Accept: application/json
-
+body:
 {
   "email": "my_email@example.com",
   "password": "password"
@@ -61,7 +63,7 @@ Request:
 GET /api/v1/forecast?<CITY AND STATE, FOR EXAMPLE denver,co>
 Content-Type: application/json
 Accept: application/json
-
+body:
 {
   "api_key": "6kzqk71x8vezd6odo5rp"
 }
@@ -72,7 +74,6 @@ Response:
 ```
 status: 200
 body:
-
 {
   "location": "Denver, C0",
   "currently": {
@@ -147,7 +148,7 @@ Request:
 POST /api/v1/favorites
 Content-Type: application/json
 Accept: application/json
-
+body:
 {
   "location": <CITY AND STATE, FOR EXAMPLE "Denver, CO">,
   api_key": "6kzqk71x8vezd6odo5rp"
@@ -160,4 +161,21 @@ body:
 {
   "message": "Denver, CO has been added to your favorites"
 }
+```
+
+### Removing a Favorite City (Denver, for example)
+Request:
+```
+DELETE /api/v1/favorites
+Content-Type: application/json
+Accept: application/json
+body:
+{
+  "location": <CITY AND STATE, FOR EXAMPLE "Denver, CO">,
+  "api_key": "6kzqk71x8vezd6odo5rp"
+}
+```
+Response:
+```
+status: 204
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "jest --watch"
+    "test": "jest -w=1 --watch"
   },
   "dependencies": {
     "bcrypt": "^3.0.6",

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,6 +1,7 @@
 var express = require("express");
 var router = express.Router();
 var User = require('../../../models').User;
+var FavoriteLocation = require('../../../models').FavoriteLocation;
 
 function unauthorized(res) {
   res.setHeader("Content-Type", "application/json");
@@ -35,6 +36,40 @@ router.post("/", function (req, res, next) {
     .catch(err => {
       res.status(500).send(JSON.stringify({ error: err }));
     })
+  }
+});
+
+/*DELETE favorite location for the user*/
+router.delete("/", function (req, res, next) {
+  let apiKey = req.body.api_key;
+  let locationString = req.body.location;
+  
+  // TODO: cover case of missing locationString
+  if (!apiKey) {
+    unauthorized(res);
+  } else {
+    User.findOne({
+      where: { apiKey: apiKey }
+    })
+    .then(user => {
+      if (user) {
+        return FavoriteLocation.destroy({
+          where: {
+            UserId: user.id,
+            name: locationString
+          }
+        })
+          .then(affectedRows => {
+            res.setHeader("Content-Type", "application/json");
+            res.status(204).send(JSON.stringify());
+          })
+      } else {
+        unauthorized(res);
+      }
+    })
+    // .catch(err => {
+    //   res.status(500).send(JSON.stringify({ error: err }));
+    // })
   }
 });
 

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -47,6 +47,11 @@ router.delete("/", function (req, res, next) {
   // TODO: cover case of missing locationString
   if (!apiKey) {
     unauthorized(res);
+  } else if (!locationString) {
+    res.setHeader("Content-Type", "application/json");
+    res.status(400).send(JSON.stringify({
+      error: 'Requires location in body of request'
+    }));
   } else {
     User.findOne({
       where: { apiKey: apiKey }
@@ -67,9 +72,9 @@ router.delete("/", function (req, res, next) {
         unauthorized(res);
       }
     })
-    // .catch(err => {
-    //   res.status(500).send(JSON.stringify({ error: err }));
-    // })
+    .catch(err => {
+      res.status(500).send(JSON.stringify({ error: err }));
+    })
   }
 });
 

--- a/tests/helper/testCleanup.js
+++ b/tests/helper/testCleanup.js
@@ -2,6 +2,8 @@ var User = require('../../models').User;
 var FavoriteLocation = require('../../models').FavoriteLocation;
 
 module.exports = async function cleanup() {
-  await User.destroy({ where: {} })
-  await FavoriteLocation.destroy({ where: {} })
+  return User.destroy({ where: {} })
+    .then(user => {
+      FavoriteLocation.destroy({ where: {} })
+    })
 }

--- a/tests/requests/favorites/delete_favorites.spec.js
+++ b/tests/requests/favorites/delete_favorites.spec.js
@@ -94,9 +94,6 @@ describe('api v1 favorites DELETE', () => {
         });
     });
 
-    // TODO: test that another user's entry of the same name is not deleted
-    // TODO: test that it doesn't error out if no resource found
-
     test('bad API key', () => {
       let email = 'email11112@example.com'
       let password = 'password'
@@ -134,10 +131,48 @@ describe('api v1 favorites DELETE', () => {
         });
     });
 
-    // TODO: test missing location string
+    test('missing location', () => {
+      let email = 'email11113@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
+
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return FavoriteLocation.create({
+            UserId: user.id,
+            name: locationString
+          })
+        })
+        .then(favoriteLocation => {
+          return request(app)
+            .del('/api/v1/favorites')
+            .send({
+              'api_key': apiKey
+            })
+        })
+        .then(response => {
+          console.log(response.body)
+          console.log(response.statusCode)
+          expect(response.statusCode).toBe(400);
+
+          expect(response.body).toEqual({
+            error: 'Requires location in body of request'
+          });
+
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(1);
+        });
+    });
 
     test('missing API key', () => {
-      let email = 'email11113@example.com'
+      let email = 'email11114@example.com'
       let password = 'password'
       let locationString = 'Denver, CO'
       const apiKey = security.randomString()

--- a/tests/requests/favorites/delete_favorites.spec.js
+++ b/tests/requests/favorites/delete_favorites.spec.js
@@ -48,37 +48,44 @@ describe('api v1 favorites DELETE', () => {
     });
 
     // TODO: test that another user's entry of the same name is not deleted
+    // TODO: test that it doesn't error out if no resource found
 
-    // test('bad API key', () => {
-    //   let email = 'email11112@example.com'
-    //   let password = 'password'
-    //   let locationString = 'Denver, CO'
-    //   const apiKey = security.randomString()
+    test('bad API key', () => {
+      let email = 'email11112@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
 
-    //   return User.create({
-    //     email: email,
-    //     passwordDigest: security.hashedPassword(password),
-    //     apiKey: apiKey
-    //   })
-    //     .then(user => {
-    //       return request(app)
-    //         .post('/api/v1/favorites')
-    //         .send({
-    //           'location': locationString,
-    //           'api_key': "badAPIkey"
-    //         })
-    //     })
-    //     .then(response => {
-    //       expect(response.statusCode).toBe(401);
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return FavoriteLocation.create({
+            UserId: user.id,
+            name: locationString
+          })
+        })
+        .then(favoriteLocation => {
+          return request(app)
+            .post('/api/v1/favorites')
+            .send({
+              'location': locationString,
+              'api_key': "badAPIkey"
+            })
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(401);
 
-    //       expect(response.body).toEqual({ error: "Invalid API key" });
+          expect(response.body).toEqual({ error: "Invalid API key" });
 
-    //       return FavoriteLocation.count()
-    //     })
-    //     .then(count => {
-    //       expect(count).toEqual(0);
-    //     });
-    // });
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(1);
+        });
+    });
 
     // test('missing API key', () => {
     //   let email = 'email11113@example.com'

--- a/tests/requests/favorites/delete_favorites.spec.js
+++ b/tests/requests/favorites/delete_favorites.spec.js
@@ -1,0 +1,107 @@
+var request = require("supertest");
+var app = require('../../../app');
+var User = require('../../../models').User;
+var FavoriteLocation = require('../../../models').FavoriteLocation;
+var security = require('../../../util/security');
+var cleanup = require('../../helper/testCleanup');
+
+describe('api v1 favorites DELETE', () => {
+  beforeEach(() => {
+    cleanup()
+  });
+
+  describe('Test the delete favorites path', () => {
+    test('returns a message', () => {
+      let email = 'email11111@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
+
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return user.createFavoriteLocation({name: locationString})
+        })
+        .then(response => {
+          return request(app)
+            .del('/api/v1/favorites')
+            .send({
+              'location': locationString,
+              'api_key': apiKey
+            })
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(204);
+
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(0);
+        });
+    });
+
+    // test('bad API key', () => {
+    //   let email = 'email11112@example.com'
+    //   let password = 'password'
+    //   let locationString = 'Denver, CO'
+    //   const apiKey = security.randomString()
+
+    //   return User.create({
+    //     email: email,
+    //     passwordDigest: security.hashedPassword(password),
+    //     apiKey: apiKey
+    //   })
+    //     .then(user => {
+    //       return request(app)
+    //         .post('/api/v1/favorites')
+    //         .send({
+    //           'location': locationString,
+    //           'api_key': "badAPIkey"
+    //         })
+    //     })
+    //     .then(response => {
+    //       expect(response.statusCode).toBe(401);
+
+    //       expect(response.body).toEqual({ error: "Invalid API key" });
+
+    //       return FavoriteLocation.count()
+    //     })
+    //     .then(count => {
+    //       expect(count).toEqual(0);
+    //     });
+    // });
+
+    // test('missing API key', () => {
+    //   let email = 'email11113@example.com'
+    //   let password = 'password'
+    //   let locationString = 'Denver, CO'
+    //   const apiKey = security.randomString()
+
+    //   return User.create({
+    //     email: email,
+    //     passwordDigest: security.hashedPassword(password),
+    //     apiKey: apiKey
+    //   })
+    //     .then(user => {
+    //       return request(app)
+    //         .post('/api/v1/favorites')
+    //         .send({
+    //           'location': locationString
+    //         })
+    //     })
+    //     .then(response => {
+    //       expect(response.statusCode).toBe(401);
+
+    //       expect(response.body).toEqual({ error: "Invalid API key" });
+
+    //       return FavoriteLocation.count()
+    //     })
+    //     .then(count => {
+    //       expect(count).toEqual(0);
+    //     });
+    // });
+  });
+});

--- a/tests/requests/favorites/delete_favorites.spec.js
+++ b/tests/requests/favorites/delete_favorites.spec.js
@@ -11,7 +11,7 @@ describe('api v1 favorites DELETE', () => {
   });
 
   describe('Test the delete favorites path', () => {
-    test('returns a message', () => {
+    test('deletes the FavoriteLocation', () => {
       let email = 'email11111@example.com'
       let password = 'password'
       let locationString = 'Denver, CO'
@@ -23,9 +23,12 @@ describe('api v1 favorites DELETE', () => {
         apiKey: apiKey
       })
         .then(user => {
-          return user.createFavoriteLocation({name: locationString})
+          return FavoriteLocation.create({
+            UserId: user.id,
+            name: locationString
+          })
         })
-        .then(response => {
+        .then(favoriteLocation => {
           return request(app)
             .del('/api/v1/favorites')
             .send({
@@ -34,6 +37,7 @@ describe('api v1 favorites DELETE', () => {
             })
         })
         .then(response => {
+          console.log(response.body);
           expect(response.statusCode).toBe(204);
 
           return FavoriteLocation.count()
@@ -42,6 +46,8 @@ describe('api v1 favorites DELETE', () => {
           expect(count).toEqual(0);
         });
     });
+
+    // TODO: test that another user's entry of the same name is not deleted
 
     // test('bad API key', () => {
     //   let email = 'email11112@example.com'

--- a/tests/requests/favorites/delete_favorites.spec.js
+++ b/tests/requests/favorites/delete_favorites.spec.js
@@ -69,7 +69,7 @@ describe('api v1 favorites DELETE', () => {
         })
         .then(favoriteLocation => {
           return request(app)
-            .post('/api/v1/favorites')
+            .del('/api/v1/favorites')
             .send({
               'location': locationString,
               'api_key': "badAPIkey"
@@ -87,34 +87,42 @@ describe('api v1 favorites DELETE', () => {
         });
     });
 
-    // test('missing API key', () => {
-    //   let email = 'email11113@example.com'
-    //   let password = 'password'
-    //   let locationString = 'Denver, CO'
-    //   const apiKey = security.randomString()
+    // TODO: test missing location string
 
-    //   return User.create({
-    //     email: email,
-    //     passwordDigest: security.hashedPassword(password),
-    //     apiKey: apiKey
-    //   })
-    //     .then(user => {
-    //       return request(app)
-    //         .post('/api/v1/favorites')
-    //         .send({
-    //           'location': locationString
-    //         })
-    //     })
-    //     .then(response => {
-    //       expect(response.statusCode).toBe(401);
+    test('missing API key', () => {
+      let email = 'email11113@example.com'
+      let password = 'password'
+      let locationString = 'Denver, CO'
+      const apiKey = security.randomString()
 
-    //       expect(response.body).toEqual({ error: "Invalid API key" });
+      return User.create({
+        email: email,
+        passwordDigest: security.hashedPassword(password),
+        apiKey: apiKey
+      })
+        .then(user => {
+          return FavoriteLocation.create({
+            UserId: user.id,
+            name: locationString
+          })
+        })
+        .then(favoriteLocation => {
+          return request(app)
+            .del('/api/v1/favorites')
+            .send({
+              'location': locationString
+            })
+        })
+        .then(response => {
+          expect(response.statusCode).toBe(401);
 
-    //       return FavoriteLocation.count()
-    //     })
-    //     .then(count => {
-    //       expect(count).toEqual(0);
-    //     });
-    // });
+          expect(response.body).toEqual({ error: "Invalid API key" });
+
+          return FavoriteLocation.count()
+        })
+        .then(count => {
+          expect(count).toEqual(1);
+        });
+    });
   });
 });

--- a/tests/requests/users/create-user.spec.js
+++ b/tests/requests/users/create-user.spec.js
@@ -25,9 +25,10 @@ describe('api v1 users', () => {
         "password_confirmation":"password"
       })
       .then(response => {
-        expect(response.statusCode).toBe(201)
-        expect(Object.keys(response.body)).toContain('api_key')
-        expect(response.body.api_key).toEqual(expect.anything())
+        expect(response.statusCode).toBe(201);
+        
+        expect(Object.keys(response.body)).toContain('api_key');
+        expect(response.body.api_key).toEqual(expect.anything());
       })
     });
 
@@ -40,9 +41,10 @@ describe('api v1 users', () => {
           "password_confirmation":"otherpassword"
         })
         .then(response => {
-          expect(response.statusCode).toBe(400)
-          expect(Object.keys(response.body)).toContain('error')
-          expect(response.body.error).toEqual("Passwords don't match")
+          expect(response.statusCode).toBe(400);
+
+          expect(Object.keys(response.body)).toContain('error');
+          expect(response.body.error).toEqual("Passwords don't match");
         })
     });
 
@@ -54,9 +56,10 @@ describe('api v1 users', () => {
           "password_confirmation":"password"
         })
         .then(response => {
-          expect(response.statusCode).toBe(400)
-          expect(Object.keys(response.body)).toContain('error')
-          expect(response.body.error).toEqual("Passwords don't match")
+          expect(response.statusCode).toBe(400);
+
+          expect(Object.keys(response.body)).toContain('error');
+          expect(response.body.error).toEqual("Passwords don't match");
         })
     });
   });


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Add `DELETE /api/v1/favorites` endpoint (resolves #8). A user can remove a location from their `FavoriteLocation`s.
 - Alters `testCleanup` -- destroy all `FavoriteLocation`s after destruction of all `User`s is complete.
 
**The following checks have been completed:**
 - [x] Tested new feature(s) as well as any feasible edge cases
 - [x] Ran the test suite - all tests are passing
 - [x] Checked affected endpoints in Postman